### PR TITLE
adapt to chef 13

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@@chef.io'
 license          'Apache-2.0'
 description      'Installs/Configures chrony, an application used to maintain the accuracy of the system clock (similar to NTP).'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
+version          '0.2.1'
 chef_version     '>= 13.0'
 issues_url 'https://github.com/chef-cookbook/chrony/issues'
 source_url 'https://github.com/chef-cookbook/chrony'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -33,10 +33,10 @@ masters = search(:node, 'recipes:chrony\:\:master') || []
 if !masters.empty?
   node.default['chrony']['servers'] = {}
   masters.each do |master|
-    node.default['chrony']['servers'][master.ipaddress] = master['chrony']['server_options']
-    node.default['chrony']['allow'].push "allow #{master.ipaddress}"
+    node.default['chrony']['servers'][master['ipaddress']] = master['chrony']['server_options']
+    node.default['chrony']['allow'].push "allow #{master['ipaddress']}"
     # only use 1 server to sync initslewstep
-    node.default['chrony']['initslewstep'] = "initslewstep 20 #{master.ipaddress}"
+    node.default['chrony']['initslewstep'] = "initslewstep 20 #{master['ipaddress']}"
   end
 else
   Chef::Log.info('No chrony master(s) found, using node[:chrony][:servers] attribute.')

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -35,7 +35,7 @@ if !node['chrony']['servers'].empty?
   keys = node['chrony']['servers'].keys.sort
   count = 3
   count = keys.length if keys.length < count
-  count.times { |x| node['chrony']['initslewstep'] += " #{keys[x]}" }
+  count.times { |x| node.default['chrony']['initslewstep'] += " #{keys[x]}" }
 else # else use first 3 clients
   clients = search(:node, 'recipes:chrony\:\:client').sort || []
   unless clients.empty?


### PR DESCRIPTION
- node.default has to be used instead of only node
- attributes can not be called like a method anymore

Signed-off-by: Michael Buege <m.buege@x-ion.de>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
