### PR TITLE
Use platform_family so we also support RHEL-like platforms like Oracle Linux

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,13 +54,13 @@ default['chrony']['systemd']['Service']['ProtectHome'] = 'yes'
 default['chrony']['systemd']['Service']['ProtectSystem'] = 'full'
 
 # these are systemd configurations that are platform-specific
-case node['platform']
-when 'redhat', 'centos'
+case node['platform_family']
+when 'rhel'
   default['chrony']['systemd']['Service']['PIDFile'] = '/run/chrony/chronyd.pid'
   default['chrony']['systemd']['Service']['EnvironmentFile'] = '-/etc/sysconfig/chronyd'
   default['chrony']['systemd']['Service']['ExecStart'] = '/usr/sbin/chronyd'
   default['chrony']['systemd']['Service']['ExecStartPost'] = '/usr/libexec/chrony-helper update-daemon'
-when 'debian', 'ubuntu'
+when 'debian'
   default['chrony']['systemd']['Service']['PIDFile'] = '/run/chronyd.pid'
   default['chrony']['systemd']['Service']['EnvironmentFile'] = '-/etc/default/chrony'
   default['chrony']['systemd']['Service']['ExecStart'] = '/usr/lib/systemd/scripts/chronyd-starter.sh $DAEMON_OPTS'


### PR DESCRIPTION
### Description
Use platform_family instead of platform for selecting systemd unit attributes. This is specifically to add support for RHEL-like platforms like Oracle Linux.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>